### PR TITLE
download transcribed text to .txt file

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,10 +13,17 @@ export interface Result {
 export default function Home() {
   const [file, setFile] = useState<File>();
   const [text, setText] = useState<string[]>([]);
+  const [downloadUrl, setDownloadUrl] = useState<any | null>(null);
 
   async function handleFormSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+
+    // clean up previous download url if there is one
+    setDownloadUrl(null);
+
+    // check for uploaded file
     if (!file) return;
+
     try {
       const formData = new FormData(event.currentTarget);
       formData.set("file", file);
@@ -27,9 +34,27 @@ export default function Home() {
       const data: Result = await response.json(); // Use the ApiResponse interface
       const dataArr = data.transcription.split('\n');
       setText(dataArr);
+
+      // create blob and url
+      const blob = new Blob([data.transcription], { type: 'text/plain' });
+      const downloadUrl = URL.createObjectURL(blob);
+      setDownloadUrl(downloadUrl);
+
+
     } catch (e: any) {
       console.error(e);
     }
+  }
+
+  const downloadTranscription = () => {
+        // Trigger a download action using a hidden link element
+        const link = document.createElement('a');
+        link.href = downloadUrl;
+        link.download = 'transcription.txt';
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+
   }
 
   return (
@@ -45,7 +70,7 @@ export default function Home() {
         <button type="submit" value="Upload" className="mt-5 py-2 px-5 rounded-full border-black border-2">Submit</button>
       </form>
       {text && <p className="py-10 px-10 mt-10 border-black border-2">{text}</p>}
-      {/* <p className="py-10 px-10 mt-10 border-black border-2">temporary</p> */}
+      <button onClick={downloadTranscription} className="mt-5 py-2 px-5 rounded-full border-black border-2">Download .txt</button>
       </div>
     </main>
   );


### PR DESCRIPTION
Transcribed text can now be downloaded by the user as a .txt file.

This requires creating a temporary <a> tag that is used as a mechanism for initiating a file download without navigating away from the page.

The process: 

- a blob object is created to represent the transcribed text as a file-like object on the browser

- a url is generated for this blob using ```URL.createObjectURL(blob)```

- <a> has a download attribute that tells the browser to download the blob (set by the href attribute ```link.href = downloadUrl```). This is set to ````transcription.txt``` which will be the new name of the file after it is downloaded
